### PR TITLE
Add auth state and route guard

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -7,6 +7,7 @@ import ChallengeDetail     from '@/views/ChallengeDetail.vue'
 import UploadView          from '@/views/UploadView.vue'
 import VoteView            from '@/views/VoteView.vue'
 import ChallengeOverview   from '@/views/ChallengeOverview.vue' // ⬅️ новый пустой child
+import { useUserStore }    from '@/stores/user'
 
 const routes = [
   { path: '/',       component: HomeView,     name: 'Home' },
@@ -19,14 +20,24 @@ const routes = [
     // ⬇️ Больше НЕТ redirect на vote — по умолчанию открывается обзор (большая карточка)
     children: [
       { path: '',       component: ChallengeOverview,           name: 'ChallengeOverview' }, // дефолт
-      { path: 'upload', component: UploadView,  props: true,    name: 'ChallengeUpload'   },
+      { path: 'upload', component: UploadView,  props: true,    name: 'ChallengeUpload', meta: { requiresAuth: true }   },
       { path: 'vote',   component: VoteView,    props: true,    name: 'ChallengeVote', meta: { compactHero: true } },
     ],
   },
-  { path: '/profile', component: ProfileView, name: 'Profile' },
+  { path: '/profile', component: ProfileView, name: 'Profile', meta: { requiresAuth: true } },
 ]
 
 export const router = createRouter({
   history: createWebHistory(),
   routes,
+})
+
+router.beforeEach((to, from, next) => {
+  const userStore = useUserStore()
+  if (to.meta.requiresAuth && !userStore.isLoggedIn) {
+    alert('Пожалуйста, войдите, чтобы продолжить')
+    next({ name: 'Home' })
+  } else {
+    next()
+  }
 })

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -4,6 +4,8 @@ import { defineStore } from 'pinia'
 
 export const useUserStore = defineStore('user', {
   state: () => ({
+    // Флаг авторизации пользователя
+    isAuthenticated: false,
     // Уникальный идентификатор пользователя
     id: 1,
 
@@ -24,6 +26,8 @@ export const useUserStore = defineStore('user', {
   }),
 
   getters: {
+    // Статус входа пользователя
+    isLoggedIn: (state) => state.isAuthenticated,
     // Текущий уровень по набранным очкам
     currentLevel: (state) => {
       const levels = [

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -43,6 +43,12 @@ const challengeStore  = useChallengeStore()
 const submissionStore = useSubmissionStore()
 const router          = useRouter()
 
+const isLoggedIn = computed(() => userStore.isLoggedIn)
+if (!isLoggedIn.value) {
+  alert('Пожалуйста, войдите, чтобы просматривать профиль')
+  router.replace({ name: 'Home' })
+}
+
 // Инициализация полей при первом заходе (если нужно)
 onMounted(() => {
   if (userStore.points === undefined) {

--- a/src/views/UploadView.vue
+++ b/src/views/UploadView.vue
@@ -114,6 +114,12 @@ const userStore        = useUserStore()
 const submissionStore  = useSubmissionStore()
 const challengeStore   = useChallengeStore()
 
+const isLoggedIn = computed(() => userStore.isLoggedIn)
+if (!isLoggedIn.value) {
+  alert('Пожалуйста, войдите, чтобы загрузить видео')
+  router.replace({ name: 'Home' })
+}
+
 const cid       = computed(() => Number(route.params.id))
 const challenge = computed(() => challengeStore.getById?.(cid.value) || null)
 


### PR DESCRIPTION
## Summary
- track login state in user store
- protect sensitive routes with auth checks
- redirect unauthenticated users from protected views

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c3709767c83279ea050e0ef1825c1