### PR TITLE
Refactor challenge data to come from store

### DIFF
--- a/src/stores/challenge.js
+++ b/src/stores/challenge.js
@@ -1,9 +1,8 @@
 // src/stores/challenge.js
 import { defineStore } from 'pinia'
 
-export const useChallengeStore = defineStore('challenge', {
-  state: () => ({
-    challenges: [
+// Начальные данные для стора. Их можно заменить загрузкой с сервера.
+const initialChallenges = [
       {
         id: 1,
         title: 'Трюк №1',
@@ -40,12 +39,22 @@ export const useChallengeStore = defineStore('challenge', {
         videoUrl: '/videos/trick3.mp4',
         // можно без постера и даты — поля просто опусти
       },
-    ],
+    ]
+
+export const useChallengeStore = defineStore('challenge', {
+  state: () => ({
+    // Стор изначально содержит исходные данные
+    challenges: initialChallenges,
   }),
   getters: {
     getById: (state) => (id) => state.challenges.find(c => c.id === Number(id)) || null,
   },
   actions: {
+    // В будущем данные могут подгружаться с сервера.
+    // Сейчас просто присваиваем initialChallenges, чтобы стор можно было сбросить.
+    async fetchChallenges() {
+      this.challenges = initialChallenges
+    },
     addParticipant(id) {
       const c = this.getById(id)
       if (c) c.participants++

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -12,55 +12,19 @@
 </template>
 
 <script setup>
-import { ref, onMounted }    from 'vue'
+import { computed, onMounted } from 'vue'
 import { useRouter }         from 'vue-router'
 import ChallengeCard         from '@/components/ChallengeCard.vue'
 import { useChallengeStore } from '@/stores/challenge'
 
-const store      = useChallengeStore()
-const challenges = ref([])
+const challengeStore = useChallengeStore()
+const challenges     = computed(() => challengeStore.challenges)
 
 const router = useRouter()
 
 onMounted(async () => {
-  if (typeof store.fetchChallenges === 'function') {
-    await store.fetchChallenges()
-  }
-  challenges.value = store.challenges
-
-  if (!challenges.value.length) {
-    challenges.value = [
-      {
-        id: 1,
-        title: 'Тестовый челлендж 1',
-        description: 'Описание тестового челленджа №1',
-        videoUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
-        isNew: true,
-        participants: 12,
-        views: 345,
-        likes: 67,
-      },
-      {
-        id: 2,
-        title: 'Тестовый челлендж 2',
-        description: 'Описание тестового челленджа №2',
-        videoUrl: 'https://www.w3schools.com/html/movie.mp4',
-        isNew: false,
-        participants: 8,
-        views: 210,
-        likes: 54,
-      },
-      {
-        id: 3,
-        title: 'Тестовый челлендж 3',
-        description: 'Ещё один тестовый челлендж',
-        videoUrl: 'https://www.w3schools.com/html/movie.mp4',
-        isNew: false,
-        participants: 5,
-        views: 100,
-        likes: 20,
-      },
-    ]
+  if (typeof challengeStore.fetchChallenges === 'function') {
+    await challengeStore.fetchChallenges()
   }
 })
 

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -59,7 +59,7 @@ const participatedCount = computed(() =>
 )
 
 const winsCount = computed(() =>
-  (challengeStore.challenges ?? []).filter(c => c.winnerId === user.id).length
+  challengeStore.challenges.filter(c => c.winnerId === user.id).length
 )
 
 /**
@@ -86,7 +86,7 @@ const userVideos = computed(() => {
  */
 function goUpload() {
   const lastFromUser = user.participated?.[user.participated.length - 1]
-  const fallback     = (challengeStore.challenges?.[0]?.id) ?? null
+  const fallback     = challengeStore.challenges[0]?.id ?? null
   const targetId     = lastFromUser ?? fallback
 
   if (targetId) {

--- a/src/views/VoteListView.vue
+++ b/src/views/VoteListView.vue
@@ -78,10 +78,8 @@ import { isVotingOpen } from '@/utils/vote'
 const challengeStore  = useChallengeStore()
 const submissionStore = useSubmissionStore()
 
-// Список челленджей
-const challenges = computed(() =>
-  challengeStore.challenges ?? challengeStore.items ?? challengeStore.list ?? []
-)
+// Список челленджей берём напрямую из стора
+const challenges = computed(() => challengeStore.challenges)
 
 // Тикер для текста «до …»
 const now = ref(Date.now())


### PR DESCRIPTION
## Summary
- Seed challenges in Pinia store with `initialChallenges` and expose `fetchChallenges`
- Home, vote list and profile views read challenges from store without hardcoded fallbacks

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c371e87f48327bb306c04e6ee480f