### PR TITLE
feat(auth): add user auth state and actions

### DIFF
--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -20,7 +20,16 @@ export const useUserStore = defineStore('user', {
     badges: ['Новичок'],
 
     // Набранные очки
-    points: 0
+    points: 0,
+
+    // Флаг аутентификации
+    isAuthenticated: false,
+
+    // Токен сессии (при необходимости можно заменить на session)
+    token: null,
+
+    // Роли пользователя
+    roles: []
   }),
 
   getters: {
@@ -72,7 +81,16 @@ export const useUserStore = defineStore('user', {
       // Здесь можно хранить структуру badge: { name, read }, 
       // но пока предполагаем, что все бейджи — прочитаны
       return 0
-    }
+    },
+
+    // Статус аутентификации
+    isAuth: (state) => state.isAuthenticated,
+
+    // Список ролей пользователя
+    userRoles: (state) => state.roles,
+
+    // Проверка наличия роли
+    hasRole: (state) => (role) => state.roles.includes(role)
   },
 
   actions: {
@@ -113,6 +131,48 @@ export const useUserStore = defineStore('user', {
       this.participated = []
       this.badges = []
       this.points = 0
+    },
+
+    /**
+     * Устанавливает данные пользователя.
+     * @param {Object} user
+     */
+    setUser(user) {
+      if (user.id !== undefined) this.id = user.id
+      if (user.name !== undefined) this.name = user.name
+      if (user.avatar !== undefined) this.avatar = user.avatar
+      if (user.participated !== undefined) this.participated = user.participated
+      if (user.badges !== undefined) this.badges = user.badges
+      if (user.points !== undefined) this.points = user.points
+      if (user.roles !== undefined) this.roles = user.roles
+    },
+
+    /**
+     * Входит в систему и сохраняет токен/сессию.
+     * @param {string|null} token
+     * @param {Object} user
+     */
+    login(token, user = {}) {
+      this.token = token
+      this.isAuthenticated = true
+      this.setUser(user)
+    },
+
+    /**
+     * Выход из системы: очищает токен и данные пользователя.
+     */
+    logout() {
+      this.token = null
+      this.isAuthenticated = false
+      this.setUser({
+        id: null,
+        name: '',
+        avatar: '/avatar.png',
+        participated: [],
+        badges: [],
+        points: 0,
+        roles: []
+      })
     }
   }
 })

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -46,9 +46,7 @@ const router          = useRouter()
 // Инициализация полей при первом заходе (если нужно)
 onMounted(() => {
   if (userStore.points === undefined) {
-    userStore.points = 0
-    userStore.participated = []
-    userStore.badges = []
+    userStore.setUser({ points: 0, participated: [], badges: [] })
   }
 })
 

--- a/src/views/UploadView.vue
+++ b/src/views/UploadView.vue
@@ -151,6 +151,7 @@ const voteUntilText = computed(() => {
 function onUploaded({ videoUrl, title }) {
   // защита на случай наступления дедлайна
   if (ended.value) return
+  if (!userStore.isAuth) return
 
   const challengeId = cid.value
   const userId = userStore.id


### PR DESCRIPTION
## Summary
- add authentication state, token storage and role support to user store
- expose login/logout/setUser actions and auth-related getters
- use setUser action in profile view and guard uploads by auth status

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c37322e7083279d1497fc9bc735b3