### PR TITLE
Add not found route and view

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -7,6 +7,7 @@ import ChallengeDetail     from '@/views/ChallengeDetail.vue'
 import UploadView          from '@/views/UploadView.vue'
 import VoteView            from '@/views/VoteView.vue'
 import ChallengeOverview   from '@/views/ChallengeOverview.vue' // ⬅️ новый пустой child
+import NotFoundView        from '@/views/NotFoundView.vue'
 
 const routes = [
   { path: '/',       component: HomeView,     name: 'Home' },
@@ -24,6 +25,7 @@ const routes = [
     ],
   },
   { path: '/profile', component: ProfileView, name: 'Profile' },
+  { path: '/:pathMatch(.*)*', name: 'NotFound', component: NotFoundView },
 ]
 
 export const router = createRouter({

--- a/src/views/NotFoundView.vue
+++ b/src/views/NotFoundView.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="flex flex-col items-center justify-center py-10">
+    <h1 class="text-2xl font-bold mb-4">404 - Страница не найдена</h1>
+    <RouterLink to="/" class="text-blue-600 hover:underline">На главную</RouterLink>
+  </div>
+</template>
+
+<script setup>
+import { RouterLink } from 'vue-router'
+</script>
+


### PR DESCRIPTION
## Summary
- add catch-all route to show a 404 page
- create simple NotFound view with link back home

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c373cfca0832790dccce75377561d