### PR TITLE
feat: centralize likes formatting

### DIFF
--- a/src/components/ChallengeCard.vue
+++ b/src/components/ChallengeCard.vue
@@ -86,7 +86,7 @@
             <path d="M13 7H7v6h6V7z"></path>
             <path fill-rule="evenodd" d="M5 3a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2H5zm10 12H5V5h10v10z" clip-rule="evenodd"></path>
           </svg>
-          {{ challenge.participants ?? 0 }}
+          {{ formatNumber(challenge.participants ?? 0) }}
         </div>
 
         <div class="flex items-center">
@@ -94,7 +94,7 @@
           <svg class="w-4 h-4 mr-1" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
             <path d="M2 5a2 2 0 012-2h12a2 2 0 012 2v8a2 2 0 01-2 2H8l-4 4V5z"></path>
           </svg>
-          {{ challenge.views ?? 0 }}
+          {{ formatNumber(challenge.views ?? 0) }}
         </div>
 
         <div class="flex items-center">
@@ -102,7 +102,7 @@
           <svg class="w-4 h-4 mr-1 text-red-500" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
             <path d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z"/>
           </svg>
-          {{ likesToShow }}
+          {{ formatNumber(likesToShow) }}
         </div>
       </div>
 
@@ -126,6 +126,7 @@
 import { computed, ref, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useSubmissionStore } from '@/stores/submission'
 import { isVotingOpen } from '@/utils/vote'
+import { defaultLikes, formatNumber } from '@/utils/format'
 
 const props = defineProps({
   challenge: { type: Object, required: true },
@@ -138,9 +139,9 @@ const submissionStore = useSubmissionStore()
 
 /* Лайки: агрегированные или из challenge */
 const likesToShow = computed(() => {
-  if (!props.aggregateLikes) return props.challenge.likes ?? 0
+  if (!props.aggregateLikes) return defaultLikes(props.challenge)
   const list = submissionStore.byChallenge?.(props.challenge.id) ?? []
-  return list.reduce((sum, s) => sum + (s.likes || 0), 0)
+  return list.reduce((sum, s) => sum + defaultLikes(s), 0)
 })
 
 /* Постер: challenge.poster → poster первого сабмишна → null */

--- a/src/components/VideoGrid.vue
+++ b/src/components/VideoGrid.vue
@@ -32,7 +32,7 @@
                 d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z"
               />
             </svg>
-            <span class="tabular-nums">{{ v.likes ?? 0 }}</span>
+            <span class="tabular-nums">{{ formatLikes(v) }}</span>
           </div>
         </div>
 
@@ -47,6 +47,7 @@
 
 <script setup>
 // Ожидаем массив объектов: { id, title, videoUrl, likes, ... }
+import { formatLikes } from '@/utils/format'
 const props = defineProps({
   videos: {
     type: Array,

--- a/src/components/VoteItem.vue
+++ b/src/components/VoteItem.vue
@@ -17,7 +17,7 @@
             d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z"
           />
         </svg>
-        <span class="tabular-nums">{{ item.likes ?? 0 }}</span>
+        <span class="tabular-nums">{{ formatLikes(item) }}</span>
       </div>
     </div>
 
@@ -58,6 +58,7 @@
 </template>
 
 <script setup>
+import { formatLikes } from '@/utils/format'
 defineProps({
   item: {
     type: Object, // { id, title, videoUrl, likes, author?, uploadedAt? }

--- a/src/components/VoteList.vue
+++ b/src/components/VoteList.vue
@@ -37,7 +37,7 @@
               <svg class="w-4 h-4 mr-1 text-red-500" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                 <path d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z"/>
               </svg>
-              <span class="font-medium">{{ e.likes ?? 0 }}</span>
+              <span class="font-medium">{{ formatLikes(e) }}</span>
             </span>
 
             <button
@@ -67,6 +67,7 @@
 </template>
 
 <script setup>
+import { formatLikes } from '@/utils/format'
 defineProps({
   entries:  { type: Array,   default: () => [] },
   hasVoted: { type: Boolean, default: false },  // общий дизейбл

--- a/src/stores/submission.js
+++ b/src/stores/submission.js
@@ -1,5 +1,6 @@
 // src/stores/submission.js
 import { defineStore } from 'pinia'
+import { defaultLikes } from '@/utils/format'
 
 let _id = 1000
 const nextId = () => ++_id
@@ -43,7 +44,7 @@ export const useSubmissionStore = defineStore('submission', {
      */
     totalLikesByChallenge: (state) => (challengeId) =>
       state.submissions.reduce(
-        (acc, s) => acc + (+s.challengeId === +challengeId ? (s.likes || 0) : 0),
+        (acc, s) => acc + (+s.challengeId === +challengeId ? defaultLikes(s) : 0),
         0
       ),
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,29 @@
+// Formatting helpers for numbers and likes counters
+// Use defaultLikes() to safely read .likes from objects
+// and formatNumber() to display numeric values with locale separators.
+
+export interface Likeable { likes?: number | null }
+
+/**
+ * Safely get the number of likes from an object.
+ * Returns 0 if item or its likes are undefined/null.
+ */
+export function defaultLikes(item?: Likeable | null): number {
+  return item?.likes ?? 0
+}
+
+/**
+ * Format a number using Intl.NumberFormat. Defaults to Russian locale.
+ */
+export function formatNumber(value: number | null | undefined, locale = 'ru-RU'): string {
+  const num = typeof value === 'number' ? value : Number(value ?? 0)
+  return new Intl.NumberFormat(locale).format(num)
+}
+
+/**
+ * Convenience helper: defaultLikes + formatNumber.
+ */
+export function formatLikes(item?: Likeable | null, locale = 'ru-RU'): string {
+  return formatNumber(defaultLikes(item), locale)
+}
+

--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -48,7 +48,7 @@
           <div class="text-sm text-gray-600 mb-4 flex flex-wrap gap-x-6 gap-y-2">
             <div>Участников: <span class="font-medium">{{ c.participants }}</span></div>
             <div>Просмотров: <span class="font-medium">{{ c.views }}</span></div>
-            <div>Лайков: <span class="font-medium">{{ aggLikes }}</span></div>
+            <div>Лайков: <span class="font-medium">{{ formatNumber(aggLikes) }}</span></div>
           </div>
 
           <div class="flex gap-4">
@@ -101,6 +101,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useChallengeStore }   from '@/stores/challenge'
 import { useSubmissionStore }  from '@/stores/submission'
 import { isVotingOpen }        from '@/utils/vote'
+import { defaultLikes, formatNumber } from '@/utils/format'
 
 const route  = useRoute()
 const router = useRouter()
@@ -113,8 +114,8 @@ const c = challengeStore.getById(Number(route.params.id))
 // Агрегированные лайки челленджа
 const aggLikes = computed(() => {
   const list = submissionStore.byChallenge?.(c?.id) ?? []
-  const sum  = list.reduce((acc, s) => acc + (s.likes || 0), 0)
-  return (c?.likes ?? 0) + sum
+  const sum  = list.reduce((acc, s) => acc + defaultLikes(s), 0)
+  return defaultLikes(c) + sum
 })
 
 // Компактный режим: только на /vote и /upload, если НЕ запросили ?full=1

--- a/src/views/UploadView.vue
+++ b/src/views/UploadView.vue
@@ -52,7 +52,7 @@
           <div class="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-gray-600 mb-4">
             <div>Участников: <span class="font-medium">{{ challenge?.participants ?? 0 }}</span></div>
             <div>Просмотров: <span class="font-medium">{{ challenge?.views ?? 0 }}</span></div>
-            <div>Лайков: <span class="font-medium">{{ aggLikes }}</span></div>
+            <div>Лайков: <span class="font-medium">{{ formatNumber(aggLikes) }}</span></div>
           </div>
 
           <div class="flex gap-3">
@@ -105,6 +105,7 @@ import { useUserStore }       from '@/stores/user'
 import { useSubmissionStore } from '@/stores/submission'
 import { useChallengeStore }  from '@/stores/challenge'
 import { isVotingOpen }       from '@/utils/vote'
+import { defaultLikes, formatNumber } from '@/utils/format'
 import VideoUploader from '@/components/VideoUploader.vue'
 
 const router = useRouter()
@@ -119,7 +120,7 @@ const challenge = computed(() => challengeStore.getById?.(cid.value) || null)
 
 // агрегированные лайки по работам — для карточки «Подробнее»
 const aggLikes = computed(() =>
-  (submissionStore.byChallenge?.(cid.value) ?? []).reduce((acc, s) => acc + (s.likes || 0), 0)
+  (submissionStore.byChallenge?.(cid.value) ?? []).reduce((acc, s) => acc + defaultLikes(s), 0)
 )
 
 // свернуто/развернуто

--- a/src/views/VoteListView.vue
+++ b/src/views/VoteListView.vue
@@ -49,7 +49,7 @@
           <div class="flex items-center flex-wrap gap-x-4 gap-y-2 text-xs text-gray-600 mb-4">
             <span>Работ: <b class="text-gray-800">{{ entriesCount(c) }}</b></span>
             <span>Участников: <b class="text-gray-800">{{ c.participants ?? 0 }}</b></span>
-            <span>Лайков: <b class="text-gray-800">{{ likesSum(c) }}</b></span>
+            <span>Лайков: <b class="text-gray-800">{{ formatNumber(likesSum(c)) }}</b></span>
           </div>
 
           <!-- CTA -->
@@ -74,6 +74,7 @@ import { computed, ref, onMounted, onBeforeUnmount } from 'vue'
 import { useChallengeStore } from '@/stores/challenge'
 import { useSubmissionStore } from '@/stores/submission'
 import { isVotingOpen } from '@/utils/vote'
+import { defaultLikes, formatNumber } from '@/utils/format'
 
 const challengeStore  = useChallengeStore()
 const submissionStore = useSubmissionStore()
@@ -102,7 +103,7 @@ function entriesCount(ch) {
 }
 function likesSum(ch) {
   const list = submissionStore.byChallenge?.(ch?.id) ?? []
-  return list.reduce((acc, s) => acc + (s.likes || 0), 0)
+  return list.reduce((acc, s) => acc + defaultLikes(s), 0)
 }
 
 // Текст «до …»

--- a/src/views/VoteView.vue
+++ b/src/views/VoteView.vue
@@ -70,7 +70,7 @@
           <div class="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-gray-600 mb-4">
             <div>Участников: <span class="font-medium">{{ challenge?.participants ?? 0 }}</span></div>
             <div>Просмотров: <span class="font-medium">{{ challenge?.views ?? 0 }}</span></div>
-            <div>Лайков: <span class="font-medium">{{ aggLikes }}</span></div>
+            <div>Лайков: <span class="font-medium">{{ formatNumber(aggLikes) }}</span></div>
           </div>
 
           <div class="flex gap-3">
@@ -137,6 +137,7 @@ import { useChallengeStore }  from '@/stores/challenge'
 import { useVotesStore }      from '@/stores/vote'
 import { useUserStore }       from '@/stores/user'
 import { isVotingOpen }       from '@/utils/vote'
+import { defaultLikes, formatNumber } from '@/utils/format'
 
 import VoteList from '@/components/VoteList.vue'
 
@@ -165,7 +166,7 @@ const hasNoVotes = computed(() => remainingVotes.value === 0)
 
 /* Сумма лайков по работам текущего челленджа */
 const aggLikes = computed(() =>
-  (entries.value ?? []).reduce((acc, s) => acc + (s.likes ?? 0), 0)
+  (entries.value ?? []).reduce((acc, s) => acc + defaultLikes(s), 0)
 )
 
 /* Сортировка */
@@ -173,7 +174,7 @@ const sort = ref('popular') // 'popular' | 'new'
 const sortedEntries = computed(() => {
   const list = entries.value.slice()
   return sort.value === 'popular'
-    ? list.sort((a, b) => (b.likes ?? 0) - (a.likes ?? 0))
+    ? list.sort((a, b) => defaultLikes(b) - defaultLikes(a))
     : list.sort((a, b) => b.id - a.id) // «новые»
 })
 


### PR DESCRIPTION
## Summary
- add formatting helpers for likes counters
- replace `likes ?? 0` checks with `formatLikes`/`defaultLikes`
- use `formatNumber` to display counters with locale formatting

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f5a397db883279dc938eaf510505c