### PR TITLE
feat: add default likes helper

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,2 @@
+export const defaultLikes = (s?: { likes?: number | null }) =>
+  typeof s?.likes === 'number' && isFinite(s.likes) ? s.likes : 0

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -32,6 +32,7 @@ import { useRouter }          from 'vue-router'
 import { useUserStore }       from '@/stores/user'
 import { useChallengeStore }  from '@/stores/challenge'
 import { useSubmissionStore } from '@/stores/submission'
+import { defaultLikes }       from '@/utils/format'
 
 import ProfileHeader   from '@/components/ProfileHeader.vue'
 import StatsBlock      from '@/components/ProfileStats.vue'
@@ -77,7 +78,7 @@ const userVideos = computed(() => {
     id: s.id,
     title: s.title,
     videoUrl: s.videoUrl,
-    likes: s.likes,
+    likes: defaultLikes(s),
     challengeId: s.challengeId,
   }))
 })


### PR DESCRIPTION
## Summary
- add `defaultLikes` utility
- use `defaultLikes` in profile video list

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f876fcc288327abed08e566e81efd