### PR TITLE
feat: format participant and view counts

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,2 +1,9 @@
 export const defaultLikes = (s?: { likes?: number | null }) =>
   typeof s?.likes === 'number' && isFinite(s.likes) ? s.likes : 0
+
+const numberFormatter = new Intl.NumberFormat('ru-RU')
+
+export const formatNumber = (value?: number | null) =>
+  typeof value === 'number' && isFinite(value)
+    ? numberFormatter.format(value)
+    : '0'

--- a/src/views/VoteView.vue
+++ b/src/views/VoteView.vue
@@ -67,8 +67,8 @@
           <p class="text-gray-600 mb-3">{{ challenge?.description }}</p>
 
           <div class="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-gray-600 mb-4">
-            <div>Участников: <span class="font-medium">{{ challenge?.participants ?? 0 }}</span></div>
-            <div>Просмотров: <span class="font-medium">{{ challenge?.views ?? 0 }}</span></div>
+            <div>Участников: <span class="font-medium">{{ formatNumber(challenge?.participants) }}</span></div>
+            <div>Просмотров: <span class="font-medium">{{ formatNumber(challenge?.views) }}</span></div>
             <div>Лайков: <span class="font-medium">{{ aggLikes }}</span></div>
           </div>
 
@@ -136,6 +136,7 @@ import { useChallengeStore }  from '@/stores/challenge'
 import { useVotesStore }      from '@/stores/vote'
 import { useUserStore }       from '@/stores/user'
 import { useCountdown }       from '@/utils/countdown'
+import { formatNumber }       from '@/utils/format'
 
 import VoteList from '@/components/VoteList.vue'
 import VideoPreview from '@/components/common/VideoPreview.vue'


### PR DESCRIPTION
## Summary
- use formatNumber to display challenge participant and view counts
- add formatNumber helper using Intl.NumberFormat

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f886844a483278feafd95832da536