### PR TITLE
Add loading and error handling to views

### DIFF
--- a/src/components/common/ErrorBlock.vue
+++ b/src/components/common/ErrorBlock.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="p-4 text-center text-red-600">
+    <slot />
+  </div>
+</template>
+
+<script setup>
+// no script
+</script>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,12 +1,21 @@
 const BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
 
+const STATUS_MESSAGES: Record<number, string> = {
+  400: 'Некорректный запрос',
+  401: 'Требуется авторизация',
+  403: 'Доступ запрещён',
+  404: 'Не найдено',
+  500: 'Ошибка сервера',
+}
+
 async function request<T>(path: string, options: RequestInit, retries: number): Promise<T> {
   const url = BASE_URL + path
   try {
     const res = await fetch(url, options)
     if (!res.ok) {
-      const message = await res.text().catch(() => res.statusText)
-      const err = new Error(message)
+      const mapped = STATUS_MESSAGES[res.status]
+      const message = mapped || (await res.text().catch(() => res.statusText))
+      const err = new Error(message || res.statusText)
       ;(err as any).status = res.status
       throw err
     }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -5,8 +5,13 @@ Display conditions:
 - Shown at route '/' after challenges are fetched.
 -->
 <template>
+  <div v-if="loading">Загрузка...</div>
+  <ErrorBlock v-else-if="error">{{ error }}</ErrorBlock>
   <!-- Адаптивная сетка: 1 / 2 / 3 колонки, карточки по центру -->
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 justify-center justify-items-center py-6">
+  <div
+    v-else
+    class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 justify-center justify-items-center py-6"
+  >
     <ChallengeCard
       v-for="c in challenges"
       :key="c.id"
@@ -18,19 +23,31 @@ Display conditions:
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
-import { useRouter }         from 'vue-router'
-import ChallengeCard         from '@/components/ChallengeCard.vue'
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import ChallengeCard from '@/components/ChallengeCard.vue'
+import ErrorBlock from '@/components/common/ErrorBlock.vue'
 import { useChallengeStore } from '@/stores/challenge'
 
 const challengeStore = useChallengeStore()
-const challenges     = computed(() => challengeStore.challenges)
+const challenges = computed(() => challengeStore.challenges)
+
+const loading = ref(true)
+const error = ref('')
 
 const router = useRouter()
 
 onMounted(async () => {
-  if (typeof challengeStore.fetchChallenges === 'function') {
-    await challengeStore.fetchChallenges()
+  loading.value = true
+  error.value = ''
+  try {
+    if (typeof challengeStore.fetchChallenges === 'function') {
+      await challengeStore.fetchChallenges()
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
   }
 })
 


### PR DESCRIPTION
## Summary
- handle HTTP errors with user-friendly messages in api
- show loading and error states in data-fetching views
- add generic ErrorBlock component for displaying errors

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c738340c8327b1a886bb20368c1a