### PR TITLE
Connect stores with API and add auth token handling

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:3000

--- a/src/stores/challenge.js
+++ b/src/stores/challenge.js
@@ -1,64 +1,29 @@
 // src/stores/challenge.js
 import { defineStore } from 'pinia'
-
-// Начальные данные для стора. Их можно заменить загрузкой с сервера.
-const initialChallenges = [
-      {
-        id: 1,
-        title: 'Трюк №1',
-        description: 'Потрясающий флип с мячом',
-        participants: 5,
-        views: 20,
-        // likes если хранишь — оставляй
-        isNew: true,
-        isHot: false,
-        videoUrl: '/videos/trick1.mp4',
-        poster: '/img/challenges/1.jpg',                 // ← опционально
-        voteEndsAt: '2025-09-30T23:59:59Z',        // ← опционально (ISO-строка)
-      },
-      {
-        id: 2,
-        title: 'Трюк №2',
-        description: 'Невозможный стиль мастера',
-        participants: 8,
-        views: 35,
-        isNew: false,
-        isHot: true,
-        videoUrl: '/videos/trick2.mp4',
-        poster: '/img/challenges/2.jpg',
-        voteEndsAt: '2025-08-09T23:59:59Z',
-      },
-      {
-        id: 3,
-        title: 'Трюк №3',
-        description: 'Безумный слэш стиль',
-        participants: 2,
-        views: 10,
-        isNew: false,
-        isHot: false,
-        videoUrl: '/videos/trick3.mp4',
-        // можно без постера и даты — поля просто опусти
-      },
-    ]
+import { fetchChallenges, fetchChallenge, put } from '@/utils/api'
 
 export const useChallengeStore = defineStore('challenge', {
   state: () => ({
-    // Стор изначально содержит исходные данные
-    challenges: initialChallenges,
+    challenges: [],
   }),
   getters: {
     getById: (state) => (id) => state.challenges.find(c => c.id === Number(id)) || null,
   },
   actions: {
-    // В будущем данные могут подгружаться с сервера.
-    // Сейчас просто присваиваем initialChallenges, чтобы стор можно было сбросить.
     async fetchChallenges() {
-      this.challenges = initialChallenges
+      this.challenges = await fetchChallenges()
     },
-    addParticipant(id) {
+    async fetchChallenge(id) {
+      const challenge = await fetchChallenge(id)
+      const idx = this.challenges.findIndex(c => c.id === challenge.id)
+      if (idx >= 0) this.challenges[idx] = challenge
+      else this.challenges.push(challenge)
+      return challenge
+    },
+    async addParticipant(id) {
+      await put(`/challenges/${id}/participants`)
       const c = this.getById(id)
-      if (c) c.participants++
-    }
-  }
+      if (c) c.participants = (c.participants || 0) + 1
+    },
+  },
 })
-

--- a/src/stores/submission.js
+++ b/src/stores/submission.js
@@ -1,84 +1,77 @@
 // src/stores/submission.js
 import { defineStore } from 'pinia'
+import { fetchChallengeVideos, post } from '@/utils/api'
 
 let _id = 1000
 const nextId = () => ++_id
 
 export const useSubmissionStore = defineStore('submission', {
   state: () => ({
-    // Тестовый сид, чтобы /votes и превью сразу ожили
-    // (challengeId: 1 и 2 имеют по 2 работы; 3 — пустой)
-    submissions: [
-      // challenge 1
-      { id: nextId(), challengeId: 1, userId: 1, title: 'Флип в упор',         videoUrl: 'https://www.w3schools.com/html/mov_bbb.mp4', likes: 7 },
-      { id: nextId(), challengeId: 1, userId: 2, title: 'Трюк под столом',     videoUrl: 'https://www.w3schools.com/html/movie.mp4',   likes: 3 },
-      // challenge 2
-      { id: nextId(), challengeId: 2, userId: 1, title: 'Смэш на вылет',       videoUrl: 'https://www.w3schools.com/html/mov_bbb.mp4', likes: 5 },
-      { id: nextId(), challengeId: 2, userId: 3, title: 'Контрудар со стенки', videoUrl: 'https://www.w3schools.com/html/movie.mp4',   likes: 2 },
-      // challenge 3 — оставляем пустым
-    ]
+    submissions: [],
   }),
 
   getters: {
-    /**
-     * Все видео пользователя
-     */
+    /** Все видео пользователя */
     byUser: (state) => (userId) =>
       state.submissions.filter(s => +s.userId === +userId),
 
-    /**
-     * Все видео конкретного челленджа
-     */
+    /** Все видео конкретного челленджа */
     byChallenge: (state) => (challengeId) =>
       state.submissions.filter(s => +s.challengeId === +challengeId),
 
-    /**
-     * Кол-во работ по челленджу (для /votes)
-     */
+    /** Кол-во работ по челленджу */
     countByChallenge: (state) => (challengeId) =>
       state.submissions.reduce((acc, s) => acc + (+s.challengeId === +challengeId ? 1 : 0), 0),
 
-    /**
-     * Сумма лайков по челленджу (для агр. метрики)
-     */
+    /** Сумма лайков по челленджу */
     totalLikesByChallenge: (state) => (challengeId) =>
       state.submissions.reduce(
         (acc, s) => acc + (+s.challengeId === +challengeId ? (s.likes || 0) : 0),
-        0
+        0,
       ),
 
-    /**
-     * Первое видео челленджа — удобно как превью на /votes
-     */
+    /** Первое видео челленджа — как превью на /votes */
     firstVideoByChallenge: (state) => (challengeId) => {
       const first = state.submissions.find(s => +s.challengeId === +challengeId)
       return first?.videoUrl || null
-    }
+    },
   },
 
   actions: {
-    /**
-     * Добавляет новую работу (возвращает её id)
-     */
-    addSubmission(challengeId, userId, videoUrl, title = 'Моя работа') {
-      const id = nextId()
+    async fetchForChallenge(challengeId) {
+      const list = await fetchChallengeVideos(challengeId)
+      this.submissions = this.submissions.filter(s => +s.challengeId !== +challengeId)
+      const mapped = list.map(v => ({
+        id: v.id,
+        challengeId: +challengeId,
+        userId: v.userId ?? 0,
+        videoUrl: v.url,
+        title: v.title ?? '',
+        likes: v.votes ?? 0,
+      }))
+      this.submissions.push(...mapped)
+    },
+
+    /** Добавляет новую работу (возвращает её id) */
+    async addSubmission(challengeId, userId, videoUrl, title = 'Моя работа') {
+      const body = { userId, url: videoUrl, title }
+      const res = await post(`/challenges/${challengeId}/videos`, body)
+      const id = res?.id ?? nextId()
       this.submissions.push({
         id,
         challengeId: +challengeId,
         userId: +userId,
         videoUrl,
         title,
-        likes: 0
+        likes: 0,
       })
       return id
     },
 
-    /**
-     * Увеличивает лайки у конкретной работы
-     */
+    /** Увеличивает лайки у конкретной работы */
     addLike(submissionId) {
       const s = this.submissions.find(x => x.id === submissionId)
       if (s) s.likes++
-    }
-  }
+    },
+  },
 })

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -1,6 +1,7 @@
 // src/stores/user.js
 
 import { defineStore } from 'pinia'
+import { post, setAuthToken } from '@/utils/api'
 
 export const useUserStore = defineStore('user', {
   state: () => ({
@@ -153,21 +154,30 @@ export const useUserStore = defineStore('user', {
 
     /**
      * Входит в систему и сохраняет токен/сессию.
-     * @param {string|null} token
-     * @param {Object} user
+     * @param {Object} credentials
      */
-    login(token, user = {}) {
+    async login(credentials) {
+      const res = await post('/login', credentials)
+      const token = res?.token || null
+      const user = res?.user || {}
       this.token = token
       this.isAuthenticated = true
+      setAuthToken(token)
+      if (token) localStorage.setItem('token', token)
       this.setUser(user)
     },
 
     /**
      * Выход из системы: очищает токен и данные пользователя.
      */
-    logout() {
+    async logout() {
+      try {
+        await post('/logout')
+      } catch {}
       this.token = null
       this.isAuthenticated = false
+      setAuthToken(null)
+      localStorage.removeItem('token')
       this.setUser({
         id: null,
         name: '',

--- a/src/stores/vote.js
+++ b/src/stores/vote.js
@@ -1,5 +1,6 @@
 // src/stores/vote.js
 import { defineStore } from 'pinia'
+import { voteVideo } from '@/utils/api'
 
 export const useVotesStore = defineStore('votes', {
   state: () => ({
@@ -40,6 +41,7 @@ export const useVotesStore = defineStore('votes', {
       const arr = this.votesByChallenge[cid] ?? (this.votesByChallenge[cid] = [])
       if (arr.includes(sid)) return false
 
+      voteVideo(sid).catch(() => {})
       arr.push(sid)
       return true
     },

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -8,10 +8,20 @@ const STATUS_MESSAGES: Record<number, string> = {
   500: 'Ошибка сервера',
 }
 
+let authToken: string | null = null
+
+export const setAuthToken = (token: string | null) => {
+  authToken = token
+}
+
 async function request<T>(path: string, options: RequestInit, retries: number): Promise<T> {
   const url = BASE_URL + path
+  const headers: Record<string, string> = {
+    ...(options.headers as Record<string, string> | undefined),
+  }
+  if (authToken) headers['Authorization'] = `Bearer ${authToken}`
   try {
-    const res = await fetch(url, options)
+    const res = await fetch(url, { ...options, headers })
     if (!res.ok) {
       const mapped = STATUS_MESSAGES[res.status]
       const message = mapped || (await res.text().catch(() => res.statusText))


### PR DESCRIPTION
## Summary
- use API utilities across challenge, submission, vote and user stores
- manage auth token in API helper and user store login/logout
- add .env with VITE_API_BASE_URL

## Testing
- ⚠️ `npm test` *(command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c93ef97483278c85686d0cd52adf