### PR TITLE
feat: integrate vkui components and dark theme

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }

--- a/src/components/common/AppContainer.vue
+++ b/src/components/common/AppContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gray-50 pb-16 flex flex-col">
+  <Panel class="min-h-screen bg-gray-50 dark:bg-gray-900 pb-16 flex flex-col">
     <!-- общий Header -->
     <Header data-app-header />
 
@@ -10,10 +10,11 @@
 
     <!-- общий BottomNav -->
     <BottomNav />
-  </div>
+  </Panel>
 </template>
 
 <script setup>
 import Header    from '@/components/common/Header.vue'
 import BottomNav from '@/components/common/BottomNav.vue'
+import Panel     from '@/components/common/Panel.vue'
 </script>

--- a/src/components/common/BadgeCarousel.vue
+++ b/src/components/common/BadgeCarousel.vue
@@ -1,14 +1,15 @@
 <template>
-  <div class="flex space-x-2 overflow-x-auto p-2 mb-4">
+  <Panel class="flex space-x-2 overflow-x-auto p-2 mb-4">
     <div
       v-for="b in badges"
       :key="b"
-      class="flex-shrink-0 bg-yellow-100 text-yellow-800 px-4 py-2 rounded-full"
+      class="flex-shrink-0 bg-yellow-100 dark:bg-yellow-800 text-yellow-800 dark:text-yellow-100 px-4 py-2 rounded-full"
     >
       {{ b }}
     </div>
-  </div>
+  </Panel>
 </template>
 <script setup>
+import Panel from '@/components/common/Panel.vue'
 defineProps({ badges: Array })
-</script
+</script>

--- a/src/components/common/BottomNav.vue
+++ b/src/components/common/BottomNav.vue
@@ -1,52 +1,59 @@
 <!-- src/components/BottomNav.vue -->
 <template>
   <nav
-    class="fixed inset-x-0 bottom-0 bg-white border-t"
+    class="fixed inset-x-0 bottom-0 bg-white dark:bg-gray-800 border-t dark:border-gray-700"
     style="padding-bottom: env(safe-area-inset-bottom)"
   >
     <div class="px-3 py-2 flex gap-2">
-      <router-link
-        :to="{ name: 'Home' }"
-        class="flex-1 inline-flex items-center justify-center rounded-xl py-2.5 text-sm font-medium border transition"
+      <Button
+        class="flex-1 rounded-xl py-2.5 text-sm font-medium border transition"
         :class="btn('Home')"
-        role="button"
+        aria-label="Челленджи"
         :aria-current="route.name === 'Home' ? 'page' : undefined"
+        tabindex="0"
+        @click="go('Home')"
       >
         Челленджи
-      </router-link>
+      </Button>
 
-      <router-link
-        :to="{ name: 'Votes' }"
-        class="flex-1 inline-flex items-center justify-center rounded-xl py-2.5 text-sm font-medium border transition"
+      <Button
+        class="flex-1 rounded-xl py-2.5 text-sm font-medium border transition"
         :class="btn('Votes')"
-        role="button"
+        aria-label="Голосование"
         :aria-current="route.name === 'Votes' ? 'page' : undefined"
+        tabindex="0"
+        @click="go('Votes')"
       >
         Голосование
-      </router-link>
+      </Button>
 
-      <router-link
-        :to="{ name: 'Profile' }"
-        class="flex-1 inline-flex items-center justify-center rounded-xl py-2.5 text-sm font-medium border transition"
+      <Button
+        class="flex-1 rounded-xl py-2.5 text-sm font-medium border transition"
         :class="btn('Profile')"
-        role="button"
+        aria-label="Профиль"
         :aria-current="route.name === 'Profile' ? 'page' : undefined"
+        tabindex="0"
+        @click="go('Profile')"
       >
         Профиль
-      </router-link>
+      </Button>
     </div>
   </nav>
 </template>
 
 <script setup>
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
+import Button from '@/components/common/Button.vue'
+
 const route = useRoute()
+const router = useRouter()
+const go = (name) => router.push({ name })
 
 // Активная — заливка; неактивная — outline
 const btn = (name) =>
   route.name === name
     ? 'bg-blue-600 text-white border-blue-600 shadow-sm'
-    : 'bg-white text-gray-700 border-gray-300 hover:border-gray-400'
+    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:border-gray-400'
 </script>
 
 <style scoped>

--- a/src/components/common/Button.vue
+++ b/src/components/common/Button.vue
@@ -1,0 +1,28 @@
+<template>
+  <button
+    :class="['vkuiButton', stylesMode[mode], stylesSize[size], block && 'w-full']"
+    v-bind="$attrs"
+  >
+    <slot />
+  </button>
+</template>
+
+<script setup>
+const props = defineProps({
+  mode: { type: String, default: 'primary' },
+  size: { type: String, default: 'm' },
+  block: { type: Boolean, default: false }
+})
+
+const stylesMode = {
+  primary: 'vkuiButton__modePrimary',
+  secondary: 'vkuiButton__modeSecondary',
+  tertiary: 'vkuiButton__modeTertiary'
+}
+
+const stylesSize = {
+  s: 'vkuiButton__sizeS',
+  m: 'vkuiButton__sizeM',
+  l: 'vkuiButton__sizeL'
+}
+</script>

--- a/src/components/common/Card.vue
+++ b/src/components/common/Card.vue
@@ -1,12 +1,9 @@
 <template>
-  <component :is="tag" class="bg-white rounded-xl shadow" v-bind="$attrs">
+  <Panel class="bg-white dark:bg-gray-800 rounded-xl shadow" v-bind="$attrs">
     <slot />
-  </component>
+  </Panel>
 </template>
 
 <script setup>
-const props = defineProps({
-  tag: { type: String, default: 'div' }
-})
+import Panel from '@/components/common/Panel.vue'
 </script>
-

--- a/src/components/common/ErrorBlock.vue
+++ b/src/components/common/ErrorBlock.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="p-4 text-center text-red-600">
+  <Panel class="p-4 text-center text-red-600 dark:text-red-400">
     <slot />
-  </div>
+  </Panel>
 </template>
 
 <script setup>
-// no script
+import Panel from '@/components/common/Panel.vue'
 </script>

--- a/src/components/common/Header.vue
+++ b/src/components/common/Header.vue
@@ -1,6 +1,6 @@
 <!-- src/components/Header.vue -->
 <template>
-  <header class="bg-white shadow-sm">
+  <header class="bg-white dark:bg-gray-800 shadow-sm">
     <div class="px-4 py-3 flex items-center justify-between">
       <!-- Лого + название -->
       <router-link to="/" class="flex items-center min-w-0">
@@ -8,20 +8,30 @@
         <span class="text-xl font-bold truncate">Клуб НT</span>
       </router-link>
 
-      <!-- Мини-профиль: аватар + имя + ранг -->
-      <router-link to="/profile" class="flex items-center gap-3 group">
-        <img
-          :src="avatarSrc"
-          alt="avatar"
-          class="h-8 w-8 rounded-full object-cover ring-1 ring-gray-200"
-        />
-        <div class="hidden sm:flex flex-col min-w-0">
-          <div class="text-sm font-medium leading-5 truncate">
-            {{ userName }}
-            <span class="ml-1 text-xs text-gray-500">· {{ levelName }}</span>
+      <div class="flex items-center gap-3">
+        <Button
+          mode="tertiary"
+          aria-label="Переключить тему"
+          tabindex="0"
+          @click="theme.toggle()"
+        >
+          {{ theme.dark ? '☀️' : '🌙' }}
+        </Button>
+        <!-- Мини-профиль: аватар + имя + ранг -->
+        <router-link to="/profile" class="flex items-center gap-3 group">
+          <img
+            :src="avatarSrc"
+            alt="avatar"
+            class="h-8 w-8 rounded-full object-cover ring-1 ring-gray-200"
+          />
+          <div class="hidden sm:flex flex-col min-w-0">
+            <div class="text-sm font-medium leading-5 truncate">
+              {{ userName }}
+              <span class="ml-1 text-xs text-gray-500">· {{ levelName }}</span>
+            </div>
           </div>
-        </div>
-      </router-link>
+        </router-link>
+      </div>
     </div>
   </header>
 </template>
@@ -30,6 +40,10 @@
 import logoUrl from '@/assets/logo.svg'
 import { computed } from 'vue'
 import { useUserStore } from '@/stores/user'
+import { useThemeStore } from '@/stores/theme'
+import Button from '@/components/common/Button.vue'
+
+const theme = useThemeStore()
 
 const userStore = useUserStore()
 

--- a/src/components/common/Panel.vue
+++ b/src/components/common/Panel.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="vkuiPanel" v-bind="$attrs">
+    <slot />
+  </div>
+</template>
+
+<script setup>
+// simple wrapper for vkui Panel styles
+</script>

--- a/src/components/common/StepIndicator.vue
+++ b/src/components/common/StepIndicator.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-center space-x-4">
+  <Panel class="flex items-center space-x-4">
     <div
       v-for="(s,i) in steps"
       :key="i"
@@ -7,7 +7,7 @@
     >
       <div
         class="mx-auto w-8 h-8 flex items-center justify-center rounded-full text-white"
-        :class="i+1 === current ? 'bg-blue-600' : 'bg-gray-300'"
+        :class="i+1 === current ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'"
       >
         {{ i+1 }}
       </div>
@@ -15,10 +15,12 @@
         {{ s }}
       </div>
     </div>
-  </div>
+  </Panel>
 </template>
 
 <script setup>
+import Panel from '@/components/common/Panel.vue'
+
 defineProps({
   steps:   { type: Array, required: true },
   current: { type: Number, required: true }

--- a/src/components/common/VideoGrid.vue
+++ b/src/components/common/VideoGrid.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="mt-4">
+  <Panel class="mt-4">
     <h3 class="text-lg font-semibold mb-2">Мои видео</h3>
 
     <!-- Пустой список -->
-    <div v-if="!videos?.length" class="text-sm text-gray-500 py-6">
+    <div v-if="!videos?.length" class="text-sm text-gray-500 dark:text-gray-400 py-6">
       Пока нет загруженных видео.
     </div>
 
@@ -13,7 +13,10 @@
         v-for="(v, i) in videos"
         :key="v.id ?? i"
         class="group cursor-pointer"
+        role="button"
+        tabindex="0"
         @click="handleSelect(v)"
+        @keydown.enter="handleSelect(v)"
       >
         <!-- Превью 16:9 -->
         <div class="relative pb-[56.25%] bg-black rounded-lg overflow-hidden">
@@ -42,10 +45,11 @@
         </div>
       </div>
     </div>
-  </div>
+  </Panel>
 </template>
 
 <script setup>
+import Panel from '@/components/common/Panel.vue'
 // Ожидаем массив объектов: { id, title, videoUrl, likes, ... }
 const props = defineProps({
   videos: {

--- a/src/components/common/VideoUploader.vue
+++ b/src/components/common/VideoUploader.vue
@@ -1,21 +1,23 @@
 <template>
   <div class="px-4 py-6 max-w-2xl mx-auto">
-    <div class="mb-4 text-sm text-gray-600">
-      <span :class="step === 1 ? 'font-semibold text-gray-800' : ''">1) Выбор видео</span>
+    <div class="mb-4 text-sm text-gray-600 dark:text-gray-300">
+      <span :class="step === 1 ? 'font-semibold text-gray-800 dark:text-white' : ''">1) Выбор видео</span>
       <span class="mx-2">→</span>
-      <span :class="step === 2 ? 'font-semibold text-gray-800' : ''">2) Предпросмотр</span>
+      <span :class="step === 2 ? 'font-semibold text-gray-800 dark:text-white' : ''">2) Предпросмотр</span>
     </div>
 
     <div v-if="step === 1" class="space-y-4">
       <input type="file" accept="video/*" @change="onFile" class="block w-full" />
-      <button
+      <Button
         type="button"
         :disabled="!file"
         @click="step = 2"
-        class="w-full px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+        block
+        aria-label="Далее"
+        tabindex="0"
       >
         Далее
-      </button>
+      </Button>
     </div>
 
     <div v-else class="space-y-4">
@@ -40,21 +42,25 @@
       />
 
       <div class="grid grid-cols-2 gap-3">
-        <button
+        <Button
           type="button"
-          class="px-4 py-2 rounded border bg-white hover:bg-gray-50"
+          class="border bg-white hover:bg-gray-50"
           @click="step = 1"
+          aria-label="Назад"
+          tabindex="0"
         >
           Назад
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
-          class="px-4 py-2 rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
+          class="bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
           :disabled="!previewUrl"
           @click="upload"
+          aria-label="Загрузить"
+          tabindex="0"
         >
           Загрузить
-        </button>
+        </Button>
       </div>
     </div>
   </div>
@@ -62,6 +68,7 @@
 
 <script setup>
 import { ref, onBeforeUnmount } from 'vue'
+import Button from '@/components/common/Button.vue'
 
 const emit = defineEmits(['uploaded'])
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import "@vkontakte/vkui/dist/vkui.css";
+@import "@vkontakte/vkui/dist/cssm/styles/themes.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/main.js
+++ b/src/main.js
@@ -3,8 +3,15 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from '@/App.vue'
 import { router } from '@/router'
+import './index.css'
+import { useThemeStore } from '@/stores/theme'
 
-createApp(App)
-  .use(createPinia())
-  .use(router)
-  .mount('#app')
+const app = createApp(App)
+const pinia = createPinia()
+app.use(pinia)
+app.use(router)
+
+const theme = useThemeStore(pinia)
+theme.apply()
+
+app.mount('#app')

--- a/src/stores/theme.js
+++ b/src/stores/theme.js
@@ -1,0 +1,20 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useThemeStore = defineStore('theme', () => {
+  const dark = ref(false)
+
+  function apply() {
+    const root = document.documentElement
+    root.classList.toggle('dark', dark.value)
+    document.body.classList.toggle('vkui--appearance-dark', dark.value)
+    document.body.classList.toggle('vkui--appearance-light', !dark.value)
+  }
+
+  function toggle() {
+    dark.value = !dark.value
+    apply()
+  }
+
+  return { dark, toggle, apply }
+})

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: ['./index.html','./src/**/*.{vue,js,ts,jsx,tsx}'],
   theme: { extend: {/*…*/} },
   plugins: [


### PR DESCRIPTION
## Summary
- enable Tailwind and PostCSS configs with class-based dark mode
- introduce VKUI-styled Button and Panel and swap custom elements
- add theme store with toggle and ARIA-friendly navigation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a0cb7e9b0c8327a75c6cb7ef0a6703