### PR TITLE
chore: configure linting and tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  extends: [
+    '@vue/eslint-config',
+    'prettier',
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  globals: {
+    defineProps: 'readonly',
+    defineEmits: 'readonly',
+    defineExpose: 'readonly',
+    withDefaults: 'readonly',
+  },
+  ignorePatterns: ['**/*.ts'],
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev":  "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint --config .eslintrc.cjs \"src/**/*.{js,vue}\" \"tests/**/*.{js,vue}\"",
+    "test": "vitest"
   },
   "dependencies": {
     "@vkontakte/icons": "^3.14.0",
@@ -22,6 +24,11 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "@testing-library/vue": "^9.4.2",
+    "@vue/eslint-config": "^1.4.0",
+    "eslint": "^9.13.0",
+    "prettier": "^3.3.2",
+    "vitest": "^2.1.4"
   }
 }

--- a/tests/ChallengeCard.test.js
+++ b/tests/ChallengeCard.test.js
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/vue'
+import { createPinia } from 'pinia'
+import ChallengeCard from '@/components/ChallengeCard.vue'
+
+describe('ChallengeCard', () => {
+  it('renders title and matches snapshot', () => {
+    const challenge = {
+      id: 1,
+      title: 'Test Challenge',
+      description: 'Desc',
+      participants: 10,
+      views: 20,
+      likes: 5,
+      videoUrl: '',
+    }
+
+    const { getByText, container } = render(ChallengeCard, {
+      global: { plugins: [createPinia()] },
+      props: { challenge },
+    })
+
+    getByText('Test Challenge')
+
+    expect(container.querySelector('h3')?.outerHTML).toMatchInlineSnapshot(`
+      "<h3 class=\"text-xl font-semibold mb-2\">Test Challenge</h3>"
+    `)
+  })
+})

--- a/tests/VideoUploader.test.js
+++ b/tests/VideoUploader.test.js
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/vue'
+import VideoUploader from '@/components/common/VideoUploader.vue'
+
+describe('VideoUploader', () => {
+  it('renders upload step and matches snapshot', () => {
+    const { getByRole } = render(VideoUploader)
+    const button = getByRole('button', { name: 'Далее' })
+    expect(button.textContent).toMatchInlineSnapshot(`"Далее"`)
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,4 +9,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
     },
   },
+  test: {
+    environment: 'jsdom',
+  },
 })


### PR DESCRIPTION
## Summary
- add eslint and prettier config files
- wire up vitest and testing-library with example component tests
- expose jsdom test environment via vite config

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: A config object is using the "env" key, which is not supported in flat config system.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ce4392dc83279de6678a742544ea