### PR TITLE
chore: pin @testing-library/vue to 8.x release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,13 @@
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.11",
-        "vite": "^7.0.4"
+        "vite": "^7.0.4",
+        "@testing-library/vue": "^8.0.0"
       }
+    },
+    "node_modules/@testing-library/vue": {
+      "version": "8.0.0",
+      "dev": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
     "vite": "^7.0.4",
-    "@testing-library/vue": "^9.4.2",
+    "@testing-library/vue": "^8.0.0",
     "@vue/eslint-config": "^1.4.0",
     "eslint": "^9.13.0",
     "prettier": "^3.3.2",


### PR DESCRIPTION
## Summary
- use published @testing-library/vue 8.x instead of unreleased 9.x
- update lockfile

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d324f4d0832784541927d770bd9b