### PR TITLE
chore: remove failing eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "tailwindcss": "^4.1.11",
     "vite": "^7.0.4",
     "@testing-library/vue": "^8.0.0",
-    "@vue/eslint-config": "^1.4.0",
     "eslint": "^9.13.0",
     "prettier": "^3.3.2",
     "vitest": "^2.1.4"


### PR DESCRIPTION
## Summary
- remove @vue/eslint-config dev dependency that blocked installation
- ensure vitest remains in devDependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d4d5c0c08327a24edf19886a106f