### PR TITLE
chore: update package-lock dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,10 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.11",
         "vite": "^7.0.4",
-        "@testing-library/vue": "^8.0.0"
+        "@testing-library/vue": "^8.0.0",
+        "eslint": "^9.13.0",
+        "prettier": "^3.3.2",
+        "vitest": "^2.1.4"
       }
     },
     "node_modules/@testing-library/vue": {
@@ -2506,6 +2509,18 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/eslint": {
+      "version": "9.13.0",
+      "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "3.3.2",
+      "dev": true
+    },
+    "node_modules/vitest": {
+      "version": "2.1.4",
+      "dev": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- add missing dev dependencies (eslint, prettier, vitest) to package-lock

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dbfc45b48327813c771ac7fc48da