### PR TITLE
chore: configure eslint flat config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,8 +1,13 @@
+const js = require('@eslint/js');
+const vue = require('eslint-plugin-vue');
+const prettier = require('eslint-config-prettier');
+
 module.exports = [
+  js.configs.recommended,
+  ...vue.configs['flat/recommended'],
   {
+    files: ['src/**/*.{js,vue}'],
     languageOptions: {
-      ecmaVersion: 'latest',
-      sourceType: 'module',
       globals: {
         defineProps: 'readonly',
         defineEmits: 'readonly',
@@ -10,6 +15,19 @@ module.exports = [
         withDefaults: 'readonly',
       },
     },
-    ignores: ['**/*.ts', '**/*.vue'],
+  },
+  {
+    files: ['tests/**/*.js'],
+    languageOptions: {
+      globals: {
+        describe: 'readonly',
+        it: 'readonly',
+        expect: 'readonly',
+      },
+    },
+  },
+  prettier,
+  {
+    ignores: ['**/*.ts'],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev":  "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint \"src/**/*.js\" \"tests/**/*.js\"",
+    "lint": "eslint \"src/**/*.{js,vue}\" \"tests/**/*.js\"",
     "test": "vitest"
   },
   "dependencies": {
@@ -26,7 +26,10 @@
     "tailwindcss": "^4.1.11",
     "vite": "^7.0.4",
     "@testing-library/vue": "^8.0.0",
+    "@eslint/js": "^9.13.0",
     "eslint": "^9.13.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-vue": "^9.29.0",
     "prettier": "^3.3.2",
     "vitest": "^2.1.4"
   }


### PR DESCRIPTION
## Summary
- switch to flat eslint config using @eslint/js and vue plugin
- update lint script to cover Vue files

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@eslint%2fjs)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a0dd8bff388327b46c65aafef70f24