### PR TITLE
Add Express backend with VK OAuth and Swagger

### DIFF
--- a/backend/knexfile.js
+++ b/backend/knexfile.js
@@ -1,0 +1,15 @@
+import 'dotenv/config';
+
+export default {
+  client: 'pg',
+  connection: {
+    host: process.env.DB_HOST || 'localhost',
+    port: process.env.DB_PORT || 5432,
+    user: process.env.DB_USER || 'postgres',
+    password: process.env.DB_PASSWORD || 'password',
+    database: process.env.DB_NAME || 'ttclub'
+  },
+  migrations: {
+    directory: './migrations'
+  }
+};

--- a/backend/migrations/20240101000000_init.js
+++ b/backend/migrations/20240101000000_init.js
@@ -1,0 +1,40 @@
+export async function up(knex) {
+  await knex.schema.createTable('users', (table) => {
+    table.increments('id').primary();
+    table.string('vk_id').unique().notNullable();
+    table.string('name');
+    table.string('avatar');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+
+  await knex.schema.createTable('challenges', (table) => {
+    table.increments('id').primary();
+    table.string('title').notNullable();
+    table.text('description');
+    table.integer('created_by').references('id').inTable('users');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+
+  await knex.schema.createTable('votes', (table) => {
+    table.increments('id').primary();
+    table.integer('challenge_id').references('id').inTable('challenges');
+    table.integer('user_id').references('id').inTable('users');
+    table.integer('value');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+
+  await knex.schema.createTable('media', (table) => {
+    table.increments('id').primary();
+    table.string('url').notNullable();
+    table.integer('challenge_id').references('id').inTable('challenges');
+    table.integer('user_id').references('id').inTable('users');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+}
+
+export async function down(knex) {
+  await knex.schema.dropTableIfExists('media');
+  await knex.schema.dropTableIfExists('votes');
+  await knex.schema.dropTableIfExists('challenges');
+  await knex.schema.dropTableIfExists('users');
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "tt-club-backend",
+  "version": "1.0.0",
+  "main": "src/server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node src/server.js",
+    "migrate": "knex migrate:latest"
+  },
+  "dependencies": {
+    "axios": "^1.7.4",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
+    "knex": "^3.1.0",
+    "pg": "^8.11.5",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.0"
+  }
+}

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,13 @@
+import jwt from 'jsonwebtoken';
+
+export default function authenticate(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.sendStatus(401);
+  const token = authHeader.split(' ')[1];
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    next();
+  } catch (e) {
+    res.sendStatus(401);
+  }
+}

--- a/backend/src/routes/challenges.js
+++ b/backend/src/routes/challenges.js
@@ -1,0 +1,35 @@
+import { Router } from 'express';
+import authenticate from '../middleware/auth.js';
+
+const router = Router();
+
+/**
+ * @swagger
+ * /challenges:
+ *   get:
+ *     summary: List challenges
+ *     responses:
+ *       200:
+ *         description: Array of challenges
+ *   post:
+ *     summary: Create challenge
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Created challenge
+ */
+router.route('/').get(async (req, res) => {
+  const list = await req.db('challenges');
+  res.json(list);
+}).post(authenticate, async (req, res) => {
+  const { title, description } = req.body;
+  const [challenge] = await req.db('challenges').insert({
+    title,
+    description,
+    created_by: req.user.id
+  }).returning('*');
+  res.json(challenge);
+});
+
+export default router;

--- a/backend/src/routes/media.js
+++ b/backend/src/routes/media.js
@@ -1,0 +1,35 @@
+import { Router } from 'express';
+import authenticate from '../middleware/auth.js';
+
+const router = Router();
+
+/**
+ * @swagger
+ * /media:
+ *   get:
+ *     summary: List media
+ *     responses:
+ *       200:
+ *         description: Array of media
+ *   post:
+ *     summary: Create media record
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Created media
+ */
+router.route('/').get(async (req, res) => {
+  const list = await req.db('media');
+  res.json(list);
+}).post(authenticate, async (req, res) => {
+  const { url, challenge_id } = req.body;
+  const [item] = await req.db('media').insert({
+    url,
+    challenge_id,
+    user_id: req.user.id
+  }).returning('*');
+  res.json(item);
+});
+
+export default router;

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+
+const router = Router();
+
+/**
+ * @swagger
+ * /users:
+ *   get:
+ *     summary: List users
+ *     responses:
+ *       200:
+ *         description: Array of users
+ */
+router.get('/', async (req, res) => {
+  const users = await req.db('users');
+  res.json(users);
+});
+
+export default router;

--- a/backend/src/routes/votes.js
+++ b/backend/src/routes/votes.js
@@ -1,0 +1,35 @@
+import { Router } from 'express';
+import authenticate from '../middleware/auth.js';
+
+const router = Router();
+
+/**
+ * @swagger
+ * /votes:
+ *   get:
+ *     summary: List votes
+ *     responses:
+ *       200:
+ *         description: Array of votes
+ *   post:
+ *     summary: Create vote
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Created vote
+ */
+router.route('/').get(async (req, res) => {
+  const list = await req.db('votes');
+  res.json(list);
+}).post(authenticate, async (req, res) => {
+  const { challenge_id, value } = req.body;
+  const [vote] = await req.db('votes').insert({
+    challenge_id,
+    value,
+    user_id: req.user.id
+  }).returning('*');
+  res.json(vote);
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,77 @@
+import express from 'express';
+import cors from 'cors';
+import knex from 'knex';
+import knexConfig from '../knexfile.js';
+import swaggerJsdoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
+import dotenv from 'dotenv';
+import axios from 'axios';
+import jwt from 'jsonwebtoken';
+
+import users from './routes/users.js';
+import challenges from './routes/challenges.js';
+import votes from './routes/votes.js';
+import media from './routes/media.js';
+
+dotenv.config();
+
+const db = knex(knexConfig);
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// VK OAuth -> JWT
+app.post('/auth/vk', async (req, res) => {
+  const { access_token } = req.body;
+  if (!access_token) return res.status(400).json({ error: 'access_token required' });
+  try {
+    const vkRes = await axios.get('https://api.vk.com/method/users.get', {
+      params: { access_token, v: '5.131' }
+    });
+    const info = vkRes.data.response[0];
+    const [user] = await db('users').insert({
+      vk_id: info.id,
+      name: `${info.first_name} ${info.last_name}`,
+      avatar: info.photo_max
+    }).onConflict('vk_id').merge().returning('*');
+    const token = jwt.sign({ id: user.id, vk_id: user.vk_id }, process.env.JWT_SECRET || 'secret', { expiresIn: '7d' });
+    res.json({ token });
+  } catch (err) {
+    res.status(401).json({ error: 'VK auth failed' });
+  }
+});
+
+app.use((req, res, next) => {
+  req.db = db;
+  next();
+});
+
+app.use('/users', users);
+app.use('/challenges', challenges);
+app.use('/votes', votes);
+app.use('/media', media);
+
+const swaggerSpec = swaggerJsdoc({
+  definition: {
+    openapi: '3.0.0',
+    info: { title: 'TT Club API', version: '1.0.0' },
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT'
+        }
+      }
+    }
+  },
+  apis: ['./src/routes/*.js']
+});
+
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- scaffold Express backend with PostgreSQL/Knex
- add VK OAuth -> JWT auth and core routes
- generate Swagger docs and enable CORS

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68a0e7b570a0832781950739c47189a8