### PR TITLE
Add VK Bridge initialization and user store sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@vkontakte/icons": "^3.14.0",
     "@vkontakte/vkui": "^7.5.3",
+    "@vkontakte/vk-bridge": "^3.0.0",
     "pinia": "^3.0.3",
     "vue": "^3.5.17",
     "vue-router": "^4.5.1"

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,8 @@ import App from '@/App.vue'
 import { router } from '@/router'
 import './index.css'
 import { useThemeStore } from '@/stores/theme'
+import { useUserStore } from '@/stores/user'
+import bridge from '@vkontakte/vk-bridge'
 
 const app = createApp(App)
 const pinia = createPinia()
@@ -13,5 +15,20 @@ app.use(router)
 
 const theme = useThemeStore(pinia)
 theme.apply()
+
+bridge.send('VKWebAppInit', {})
+
+bridge
+  .send('VKWebAppGetUserInfo')
+  .then((data) => {
+    const userStore = useUserStore(pinia)
+    userStore.setUser({
+      id: data.id,
+      name: `${data.first_name} ${data.last_name}`,
+      avatar: data.photo_100,
+    })
+    userStore.isAuthenticated = true
+  })
+  .catch((err) => console.error('VK init failed', err))
 
 app.mount('#app')


### PR DESCRIPTION
## Summary
- add `@vkontakte/vk-bridge` dependency
- initialize VK Bridge and fetch user info
- store VK user data in Pinia user store

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a1a5600250832793b1bfca09d651c3