### PR TITLE
feat: integrate VK auth

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -14,7 +14,7 @@ Requests requiring authentication must include the header:
 Authorization: Bearer <token>
 ```
 
-Tokens are obtained via the login endpoint.
+Tokens are obtained via the `POST /auth/vk` endpoint using a VK access token.
 
 ## Error Format
 
@@ -31,9 +31,9 @@ Errors follow JSON structure with standard HTTP status codes:
 
 ## Endpoints
 
-### `POST /auth/login`
-- **Description:** Obtain an access token for authenticated requests.
-- **Body:** `{ "username": "string", "password": "string" }`
+### `POST /auth/vk`
+- **Description:** Exchange a VK `access_token` for an API JWT.
+- **Body:** `{ "access_token": "string" }`
 - **Response:** `{ "token": "string" }`
 
 ### `GET /members`

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -5,8 +5,6 @@ import { post, setAuthToken } from '@/utils/api'
 
 export const useUserStore = defineStore('user', {
   state: () => ({
-    // Флаг авторизации пользователя
-    isAuthenticated: false,
     // Уникальный идентификатор пользователя
     id: 1,
 
@@ -153,27 +151,25 @@ export const useUserStore = defineStore('user', {
     },
 
     /**
-     * Входит в систему и сохраняет токен/сессию.
-     * @param {Object} credentials
+     * Авторизация через VK: отправляет VK access_token на сервер,
+     * сохраняет выданный JWT и помечает пользователя как аутентифицированного.
+     * @param {string} accessToken VK access_token
      */
-    async login(credentials) {
-      const res = await post('/login', credentials)
+    async login(accessToken) {
+      const res = await post('/auth/vk', { access_token: accessToken })
       const token = res?.token || null
-      const user = res?.user || {}
-      this.token = token
-      this.isAuthenticated = true
-      setAuthToken(token)
-      if (token) localStorage.setItem('token', token)
-      this.setUser(user)
+      if (token) {
+        this.token = token
+        this.isAuthenticated = true
+        setAuthToken(token)
+        localStorage.setItem('token', token)
+      }
     },
 
     /**
-     * Выход из системы: очищает токен и данные пользователя.
+     * Выход из системы: очищает токен и данные пользователя (серверных вызовов нет).
      */
     async logout() {
-      try {
-        await post('/logout')
-      } catch {}
       this.token = null
       this.isAuthenticated = false
       setAuthToken(null)


### PR DESCRIPTION
## Summary
- use `/auth/vk` for login and store returned JWT
- remove backend `/login` and `/logout` calls in store
- document VK login flow in API docs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a1a6b8883c8327bbc7c1045f02bb96