### PR TITLE
chore: configure domain and env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,28 @@ The `src/components/common/` directory contains reusable components shared acros
 
 ## Documentation
 Detailed documentation, including style guides and user scenarios, can be found in [docs/](docs/README.md).
+
+## Environment Variables
+
+### Frontend
+Create a `.env` file in the project root and specify the backend API URL:
+
+```
+VITE_API_BASE_URL=https://tt-club.ru/api
+```
+
+Adjust the URL as needed for your deployment.
+
+### Backend
+Copy `backend/.env.example` to `backend/.env` and provide database credentials and secrets:
+
+```
+DB_HOST=localhost
+DB_USER=postgres
+DB_PASSWORD=password
+DB_NAME=ttclub
+JWT_SECRET=change_me
+SENTRY_DSN=
+```
+
+These values configure database connection, JWT signing, and Sentry reporting.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Detailed documentation, including style guides and user scenarios, can be found 
 Create a `.env` file in the project root and specify the backend API URL:
 
 ```
-VITE_API_BASE_URL=https://tt-club.ru/api
+VITE_API_BASE_URL=https://stuch.online/api
 ```
 
 Adjust the URL as needed for your deployment.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=localhost
+DB_USER=postgres
+DB_PASSWORD=password
+DB_NAME=ttclub
+JWT_SECRET=change_me
+SENTRY_DSN=

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -2,7 +2,7 @@
 
 server {
   listen 80;
-  server_name example.com;
+  server_name tt-club.ru;
   location / {
     return 301 https://$host$request_uri;
   }
@@ -10,10 +10,10 @@ server {
 
 server {
   listen 443 ssl http2;
-  server_name example.com;
+  server_name tt-club.ru;
 
-  ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+  ssl_certificate /etc/letsencrypt/live/tt-club.ru/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/tt-club.ru/privkey.pem;
   include /etc/letsencrypt/options-ssl-nginx.conf;
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -2,7 +2,7 @@
 
 server {
   listen 80;
-  server_name tt-club.ru;
+  server_name stuch.online;
   location / {
     return 301 https://$host$request_uri;
   }
@@ -10,10 +10,10 @@ server {
 
 server {
   listen 443 ssl http2;
-  server_name tt-club.ru;
+  server_name stuch.online;
 
-  ssl_certificate /etc/letsencrypt/live/tt-club.ru/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/tt-club.ru/privkey.pem;
+  ssl_certificate /etc/letsencrypt/live/stuch.online/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/stuch.online/privkey.pem;
   include /etc/letsencrypt/options-ssl-nginx.conf;
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 


### PR DESCRIPTION
## Summary
- point Nginx config to tt-club.ru with correct certificate paths
- add backend .env example
- document frontend and backend environment setup

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a1ea66a0d4832785cf0e044210db7f