### PR TITLE
Run lint and tests in CI and deploy backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,10 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - run: npm run lint
+      - run: npm test
       - run: npm run build
-      - name: Deploy
+      - name: Deploy frontend
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.SERVER_HOST }}
@@ -23,3 +25,22 @@ jobs:
           key: ${{ secrets.SERVER_SSH_KEY }}
           source: "dist/*"
           target: "/var/www/tt-club/"
+      - name: Deploy backend
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          source: "backend/**"
+          target: "/var/www/tt-club/backend/"
+      - name: Install and restart backend
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            cd /var/www/tt-club/backend
+            npm ci --production
+            npm run migrate
+            pm2 restart tt-club || pm2 start src/server.js --name tt-club

--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ SENTRY_DSN=
 ```
 
 These values configure database connection, JWT signing, and Sentry reporting.
+
+## CI/CD
+
+GitHub Actions handles continuous integration and deployment:
+
+- On every push or pull request, the workflow installs dependencies and runs `npm run lint` and `npm test`.
+- The frontend is built with `npm run build` and uploaded to `/var/www/tt-club/` on the server.
+- The `backend/` directory is copied to the server, dependencies are installed, database migrations are executed, and the service is started (or restarted) with PM2.
+
+To enable deployments, configure the repository secrets `SERVER_HOST`, `SERVER_USER`, and `SERVER_SSH_KEY` with credentials for the target server.


### PR DESCRIPTION
## Summary
- run `npm run lint` and `npm test` in CI
- deploy backend alongside frontend and restart via pm2
- document CI/CD setup

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f02b96c4832788e77c2ccaf65b3c